### PR TITLE
Feature: better api and deps update

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ The idea is that the component wraps the conection, and you pass "raw" Redis com
 
 If you want to mock the component - you'll need something that implements the following:
 
-- `(execute* this <command> & args)` - for  single commands
-- `(exececute-pipeline* this [ [command1  & args] [command2 & args]...])` - for pipeline
+- `(execute this [:command + args])` - for  single commands
+- `(exececute-pipeline this [ [:command1  & args] [:command2 & args]...])` - for pipeline operations
 
 and fakes Redis behavior as needed.
 
@@ -34,27 +34,35 @@ and fakes Redis behavior as needed.
             [com.stuartsierra.component :as component]))
 
 (let [red (componet/start (omega-red.redis/create {:host "127.0.0.1" :port 6379}))]
-    (println (= 0 (proto/execute red :exists "test.some.key"))) ; true
-    (println (= "OK" (proto/execute red :set "test.some.key" "foo"))) ; true
-    (println (= 1 (proto/execute red :exists "test.some.key"))) ; true
-    (println (= "foo" (proto/execute red :get "test.some.key"))) ; true
-    (println (= 1 (proto/execute red :del "test.some.key"))) ; true
+    (println (= 0 (proto/execute red [:exists "test.some.key"]))) ; true
+    (println (= "OK" (proto/execute red [:set "test.some.key" "foo"]))) ; true
+    (println (= 1 (proto/execute red [:exists "test.some.key"]))) ; true
+    (println (= "foo" (proto/execute red [:get "test.some.key"]))) ; true
+    (println (= 1 (proto/execute red [:del "test.some.key"]))) ; true
     (component/stop red)
-    (println (nil? (proto/execute red :get "test.some.key")))) ; true
+    (println (nil? (proto/execute red [:get "test.some.key"])))) ; true
 
 ;; pipeline execution
 (println (= [nil "OK" "oh ok" 1]
        (proto/execute-pipeline red
-                               [:get "test.some.key.pipe"]
-                               [:set "test.some.key.pipe" "oh ok"]
-                               [:get "test.some.key.pipe"]
-                               [:del "test.some.key.pipe"]))) ; true
+                               [[:get "test.some.key.pipe"]
+                                [:set "test.some.key.pipe" "oh ok"]
+                                [:get "test.some.key.pipe"]
+                                [:del "test.some.key.pipe"]]))) ; true
 
 ```
 
+## Change log
+
+
+- 1.0.0-SNAPSHOT - **Breaking change!** Changes signature of `execute` to accept a vector, similar to `execute-pipeline`. This makes it easier to work with variadic Redis commands (`hmset` etc)
+- 0.1.0- 2019/10/23 - Initial Public Offering
+
 # Roadmap
 
-Nothing at the moment. It's possible to create Components for Carmine's various exentions (message queue, Tundra) but they're not needed at the moment.
+- [ ] explicit connection pool component with its own lifecycle
+- [ ] *maybe* move off Carmine and use Jedis or Lettuce directly (because of the point above)
+
 
 # Authors
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nomnom/omega-red "0.1.0"
+(defproject nomnom/omega-red "1.0.0-SNAPSHOT"
   :description "Component firendly Redis client, based on Carmine"
   :url "https://github.com/nomnom-insights/nomnom.omega-red"
   :license {:name "MIT License"
@@ -6,8 +6,8 @@
             :year 2018
             :key "mit"}
   :deploy-repositories {"clojars" {:sign-releases false
-                                   :username [:gpg :env/clojars_username]
-                                   :password [:gpg :env/clojars_password]}}
+                                   :username :env/clojars_username
+                                   :password  :env/clojars_password}}
   :dependencies [[org.clojure/clojure "1.10.2"]
                  [com.stuartsierra/component "1.0.0"]
                  [com.taoensso/carmine "3.1.0"]]

--- a/project.clj
+++ b/project.clj
@@ -8,9 +8,9 @@
   :deploy-repositories {"clojars" {:sign-releases false
                                    :username [:gpg :env/clojars_username]
                                    :password [:gpg :env/clojars_password]}}
-  :dependencies [[org.clojure/clojure "1.10.0"]
-                 [com.stuartsierra/component "0.4.0"]
-                 [com.taoensso/carmine "2.19.1"]]
+  :dependencies [[org.clojure/clojure "1.10.2"]
+                 [com.stuartsierra/component "1.0.0"]
+                 [com.taoensso/carmine "3.1.0"]]
   :plugins [[lein-cloverage "1.0.13" :exclusions [org.clojure/clojure]]]
   :profiles {:dev
-             {:dependencies  [[org.clojure/tools.logging "0.5.0-alpha.1"]]}})
+             {:dependencies  [[org.clojure/tools.logging "1.1.0"]]}})

--- a/src/omega_red/protocol.clj
+++ b/src/omega_red/protocol.clj
@@ -1,26 +1,8 @@
 (ns omega-red.protocol)
 
+
 (defprotocol Redis
-  ;; Protocols do not support var-args (without macro magic)
-  ;; The idea is that we  define a wrapper fn which is variadic and dispatch on that
-  ;; A bit odd, but works when outside,
-  ;; with the exception that record implementing the interface has to implement
-  ;; execute* and execute-pipeline*
-  (execute* [this redis-fn args]
-    "Executes single redis command - use omega-red.protocol/execute to invoke!")
-  (execute-pipeline* [this redis-fns+args]
+  (execute [this redis-fn+args]
+    "Executes single redis command - passed as JDBC-style vector: [:command the rest of args]")
+  (execute-pipeline [this redis-fns+args]
     "Executes a series of commands + their args in a pipeline. Commands are a vector of vecs with the commands and their args. Use omega-red.protocol/excute-pipeline to invoke!"))
-
-(defn execute
-  "Wrapper function to allow variadic args dispatch.
-  Invokes a redis command + its args:
-  (execute redis :get \"key.name\")"
-  [this redis-fn & args]
-  (execute* this redis-fn args))
-
-(defn execute-pipeline
-  "Wrapper function to allow variadic args dispatch.
-  Executes a series of redis commands in a pipeline:
-  (execute-pipeline redis [:get \"key\"] [:del \"key\"]"
-  [this & redis-fns+args]
-  (execute-pipeline* this redis-fns+args))

--- a/test/omega_red/redis_test.clj
+++ b/test/omega_red/redis_test.clj
@@ -1,26 +1,29 @@
 (ns omega-red.redis-test
-  (:require [omega-red.protocol :as proto]
-            [omega-red.redis]
-            [clojure.test :refer :all]))
+  (:require
+    [clojure.test :refer :all]
+    [omega-red.protocol :as proto]
+    [omega-red.redis]))
+
 
 (deftest redis-ops
   (let [red (.start (omega-red.redis/create {:host "127.0.0.1" :port 6379}))]
-    (is (= 0 (proto/execute red :exists "test.some.key")))
-    (is (= "OK" (proto/execute red :set "test.some.key" "foo")))
-    (is (= 1 (proto/execute red :exists "test.some.key")))
-    (is (= "foo" (proto/execute red :get "test.some.key")))
-    (is (= 1 (proto/execute red :del "test.some.key")))
+    (is (= 0 (proto/execute red [:exists "test.some.key"])))
+    (is (= "OK" (proto/execute red [:set "test.some.key" "foo"])))
+    (is (= 1 (proto/execute red [:exists "test.some.key"])))
+    (is (= "foo" (proto/execute red [:get "test.some.key"])))
+    (is (= 1 (proto/execute red [:del "test.some.key"])))
     (.stop red)
-    (is (nil? (proto/execute red :get "test.some.key")))))
+    (is (nil? (proto/execute red [:get "test.some.key"])))))
+
 
 (deftest redis-pipelne
   (let [red (.start (omega-red.redis/create {:host "127.0.0.1" :port 6379}))]
-    (is (= 0 (proto/execute red :exists "test.some.key.pipe")))
+    (is (= 0 (proto/execute red [:exists "test.some.key.pipe"])))
     (is (= [nil "OK" "oh ok" 1]
            (proto/execute-pipeline red
-                                   [:get "test.some.key.pipe"]
-                                   [:set "test.some.key.pipe" "oh ok"]
-                                   [:get "test.some.key.pipe"]
-                                   [:del "test.some.key.pipe"])))
-    (is (= 0 (proto/execute red :exists "test.some.key.pipe")))
+                                   [[:get "test.some.key.pipe"]
+                                    [:set "test.some.key.pipe" "oh ok"]
+                                    [:get "test.some.key.pipe"]
+                                    [:del "test.some.key.pipe"]])))
+    (is (= 0 (proto/execute red [:exists "test.some.key.pipe"])))
     (.stop red)))


### PR DESCRIPTION
This is a **breaking change**, hence the major version bump.

Apart from updating dependencies, which is always nice, this changes Omega Red's API from:

```clojure
(redis/execute conn :get "some-key")
```

to

```clojure
(redis/execute conn [:get "some-key"])
```

Similarly, pipelines go from:

```clojure

(redis/execute-pipeline conn [:get "key 1"] [:get "key 2"])
```

to

```clojure
(redis/execute-pipeline conn [[:get "key 1"] [:get "key 2"]])
```


This makes commands/queries more composable and removes the layer of indirection that was introduced because protocols do not support varags. 
